### PR TITLE
Fix copy frameworks

### DIFF
--- a/Source/UticaKit/Xcode.swift
+++ b/Source/UticaKit/Xcode.swift
@@ -1434,6 +1434,10 @@ public func nonDestructivelyStripArchitectures(_ frameworkURL: URL, _ architectu
         }
 
       return task.then(result)
+        .attempt { _ in
+          try? FileManager.default.removeItem(at: tempDir)
+          return .success(())
+        }
     }
 }
 


### PR DESCRIPTION
The overall issue was already fixed here https://github.com/Carthage/Carthage/commit/2cbc64527e825c87a95b0123b856a9e74f7c3f81.
I have just added a dummy cleanup step to cover the case when the number of temp folders increasing.