### PR TITLE
Fix 'objdump' call not working with >= Xcode 13.3 command line tools

### DIFF
--- a/IntegrationTests/binary.bats
+++ b/IntegrationTests/binary.bats
@@ -2,6 +2,7 @@
 
 setup() {
     cd $BATS_TMPDIR
+    echo $BATS_TMPDIR
     rm -rf BinaryTest
     mkdir BinaryTest && cd BinaryTest
     echo 'binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAnalyticsBinary.json"' > Cartfile
@@ -15,5 +16,5 @@ teardown() {
     run utica update --platform iOS --valid-simulator-archs "i386 x86_64"
 
     [ "$status" -eq 0 ]
-    [ -d Carthage/Build/iOS/Firebase.framework ]
+    [ -d Carthage/Build/FirebaseAnalytics.xcframework ]
 }

--- a/IntegrationTests/binary.bats
+++ b/IntegrationTests/binary.bats
@@ -14,7 +14,7 @@ teardown() {
 
 @test "utica update builds everything (binary)" {
     run utica update --platform iOS --valid-simulator-archs "i386 x86_64"
-    echo $BATS_TMPDIR
+
     [ "$status" -eq 0 ]
     [ -d Carthage/Build/FirebaseAnalytics.xcframework ]
     [ -d Carthage/Build/iOS/Appboy_iOS_SDK.framework ]

--- a/IntegrationTests/binary.bats
+++ b/IntegrationTests/binary.bats
@@ -5,6 +5,7 @@ setup() {
     rm -rf BinaryTest
     mkdir BinaryTest && cd BinaryTest
     echo 'binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAnalyticsBinary.json"' > Cartfile
+    echo 'binary "https://raw.githubusercontent.com/Appboy/appboy-ios-sdk/master/appboy_ios_sdk.json" == 4.3.2' >> Cartfile
 }
 
 teardown() {
@@ -13,7 +14,8 @@ teardown() {
 
 @test "utica update builds everything (binary)" {
     run utica update --platform iOS --valid-simulator-archs "i386 x86_64"
-
+    echo $BATS_TMPDIR
     [ "$status" -eq 0 ]
     [ -d Carthage/Build/FirebaseAnalytics.xcframework ]
+    [ -d Carthage/Build/iOS/Appboy_iOS_SDK.framework ]
 }

--- a/IntegrationTests/binary.bats
+++ b/IntegrationTests/binary.bats
@@ -2,7 +2,6 @@
 
 setup() {
     cd $BATS_TMPDIR
-    echo $BATS_TMPDIR
     rm -rf BinaryTest
     mkdir BinaryTest && cd BinaryTest
     echo 'binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAnalyticsBinary.json"' > Cartfile

--- a/IntegrationTests/update.bats
+++ b/IntegrationTests/update.bats
@@ -2,6 +2,7 @@
 
 setup() {
     cd $BATS_TMPDIR
+    echo $BATS_TMPDIR
     rm -rf UpdateTest
     mkdir UpdateTest && cd UpdateTest
     echo 'github "antitypical/Result" == 5.0.0' > Cartfile

--- a/IntegrationTests/update.bats
+++ b/IntegrationTests/update.bats
@@ -2,11 +2,10 @@
 
 setup() {
     cd $BATS_TMPDIR
-    echo $BATS_TMPDIR
     rm -rf UpdateTest
     mkdir UpdateTest && cd UpdateTest
     echo 'github "antitypical/Result" == 5.0.0' > Cartfile
-    echo 'github "Quick/Nimble" == 8.0.4' > Cartfile.private
+    echo 'github "Quick/Nimble" == 10.0.0' > Cartfile.private
 }
 
 teardown() {

--- a/Source/UticaKit/CarthageKitVersion.swift
+++ b/Source/UticaKit/CarthageKitVersion.swift
@@ -4,5 +4,5 @@ import Foundation
 public struct CarthageKitVersion {
   public let value: SemanticVersion
 
-  public static let current = CarthageKitVersion(value: SemanticVersion(0, 40, 0))
+  public static let current = CarthageKitVersion(value: SemanticVersion(0, 40, 1))
 }

--- a/Source/UticaKit/MachHeader.swift
+++ b/Source/UticaKit/MachHeader.swift
@@ -69,9 +69,9 @@ extension MachHeader {
       "/usr/bin/xcrun",
       arguments: [
         "objdump",
-        "-macho",
-        "-private-header",
-        "-non-verbose",
+        "--macho",
+        "--private-header",
+        "--non-verbose",
         url.resolvingSymlinksInPath().path
       ]
     )

--- a/Tests/UticaKitTests/CartfileCommentsSpec.swift
+++ b/Tests/UticaKitTests/CartfileCommentsSpec.swift
@@ -6,6 +6,7 @@ class CarfileCommentsSpec: QuickSpec {
   override func spec() {
     describe("removing carfile comments") {
       it("should not alter strings with no comments") {
+        let patterns: [String] =
         [
           "foo bar\nbaz",
           "",
@@ -16,18 +17,19 @@ class CarfileCommentsSpec: QuickSpec {
           "unopened\"",
           "I say \"hello\" you say \"goodbye\"!"
         ]
-        .forEach {
+        patterns.forEach {
           expect($0.strippingTrailingCartfileComment) == $0
         }
       }
 
       it("should not alter strings with comment marker in quotes") {
+        let patterns: [String] =
         [
           "foo bar \"#baz\"",
           "\"#quotes\" is the new \"quotes\"",
           "\"#\""
         ]
-        .forEach {
+        patterns.forEach {
           expect($0.strippingTrailingCartfileComment) == $0
         }
       }


### PR DESCRIPTION
Fixes https://github.com/Carthage/Carthage/issues/3253